### PR TITLE
Make lower case optional

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+test

--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ npm install slugg
 
 ## Usage:
 
-### slug(string, [separator])
+### slug(string, [separator, toStrip])
 
 ```js
 var slug = require('slugg')
@@ -48,3 +48,31 @@ slug('Mum\'s cooking', /'/g)
 ```
 
 Remember to use the `g` flag if you want all the matches stripped (not just the first).
+
+After version 1.1.0, a new syntax has been introduced:
+
+### slug(string, [options])
+
+If you want a separator other than '-', pass it in as the `separator` option:
+
+```js
+slug('Kevin Spacey', { separator: ' ' })
+//-> 'kevin spacey'
+```
+
+If you want to control which characters are stripped, pass a regex as the `toStrip` option
+that will match the chars you want to replace, eg:
+
+```js
+slug('Mum\'s cooking', { toStrip: /'/g })
+//-> 'mums-cooking'
+```
+Remember to use the `g` flag if you want all the matches stripped (not just the first).
+
+By default, slugg will convert your string to lower case. If you want to disable it just
+pass the `toLowerCase` option as `false`, eg:
+
+```js
+slug('Slugg rocks!', { toLowerCase: false })
+//-> 'Slugg-rocks'
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slugg",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "Make strings url safe (with no dependencies)",
   "publishConfig": {
     "registry": "http://registry.npmjs.org/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slugg",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Make strings url safe (with no dependencies)",
   "publishConfig": {
     "registry": "http://registry.npmjs.org/"

--- a/slugg.js
+++ b/slugg.js
@@ -1,20 +1,46 @@
 (function (root) {
 
 var defaultSeparator = '-'
+var defaultToStrip = /['"’‘”“]/g
+var defaultToLowerCase = true
 
 function slugg(string, separator, toStrip) {
 
-  // Separator is optional
-  if (typeof separator === 'undefined') separator = defaultSeparator
+  var options = {}
 
-  // Separator might be omitted and toStrip in its place
-  if (separator instanceof RegExp) {
-    toStrip = separator
-    separator = defaultSeparator
+  if (typeof separator === 'object') {
+    options = separator
+
+    // Separator is optional
+    if (typeof options.separator === 'undefined') options.separator = defaultSeparator
+
+    // toStrip is optional
+    if (typeof options.toStrip === 'undefined') options.toStrip = defaultToStrip
+
+    // toLowerCase is optional
+    if (typeof options.toLowerCase === 'undefined') options.toLowerCase = defaultToLowerCase
+  } else {
+    options.separator = separator
+    options.toStrip = toStrip
+
+    // Separator is optional
+    if (typeof options.separator === 'undefined') options.separator = defaultSeparator
+
+    // Separator might be omitted and toStrip in its place
+    if (options.separator instanceof RegExp) {
+      options.toStrip = separator
+      options.separator = defaultSeparator
+    }
+
+    // Only a separator was passed
+    if (typeof options.toStrip === 'undefined') options.toStrip = /['"’‘”“]/g
+
+    // Keep default behavior
+    options.toLowerCase = defaultToLowerCase
   }
 
-  // Only a separator was passed
-  if (typeof toStrip === 'undefined') toStrip = /['"’‘”“]/g
+  // Make lower-case
+  if (options.toLowerCase) string = string.toLowerCase()
 
   // Swap out non-english characters for their english equivalent
   for (var i = 0, len = string.length; i < len; i++) {
@@ -24,16 +50,14 @@ function slugg(string, separator, toStrip) {
   }
 
   string = string
-    // Make lower-case
-    .toLowerCase()
     // Strip chars that shouldn't be replaced with separator
-    .replace(toStrip, '')
+    .replace(options.toStrip, '')
     // Replace non-word characters with separator
-    .replace(/[\W|_]+/g, separator)
+    .replace(/[\W|_]+/g, options.separator)
     // Strip dashes from the beginning
-    .replace(new RegExp('^' + separator + '+'), '')
+    .replace(new RegExp('^' + options.separator + '+'), '')
     // Strip dashes from the end
-    .replace(new RegExp(separator + '+$'), '')
+    .replace(new RegExp(options.separator + '+$'), '')
 
   return string
 

--- a/slugg.js
+++ b/slugg.js
@@ -10,21 +10,9 @@ function slugg(string, separator, toStrip) {
 
   if (typeof separator === 'object') {
     options = separator
-
-    // Separator is optional
-    if (typeof options.separator === 'undefined') options.separator = defaultSeparator
-
-    // toStrip is optional
-    if (typeof options.toStrip === 'undefined') options.toStrip = defaultToStrip
-
-    // toLowerCase is optional
-    if (typeof options.toLowerCase === 'undefined') options.toLowerCase = defaultToLowerCase
   } else {
     options.separator = separator
     options.toStrip = toStrip
-
-    // Separator is optional
-    if (typeof options.separator === 'undefined') options.separator = defaultSeparator
 
     // Separator might be omitted and toStrip in its place
     if (options.separator instanceof RegExp) {
@@ -34,10 +22,16 @@ function slugg(string, separator, toStrip) {
 
     // Only a separator was passed
     if (typeof options.toStrip === 'undefined') options.toStrip = /['"’‘”“]/g
-
-    // Keep default behavior
-    options.toLowerCase = defaultToLowerCase
   }
+
+  // Separator is optional
+  if (typeof options.separator === 'undefined') options.separator = defaultSeparator
+
+  // toStrip is optional
+  if (typeof options.toStrip === 'undefined') options.toStrip = defaultToStrip
+
+  // toLowerCase is optional
+  if (typeof options.toLowerCase === 'undefined') options.toLowerCase = defaultToLowerCase
 
   // Make lower-case
   if (options.toLowerCase) string = string.toLowerCase()

--- a/test/slugg.test.js
+++ b/test/slugg.test.js
@@ -38,6 +38,8 @@ describe('slug()', function () {
   it('should use a custom separator if present', function () {
     assert.equal(slug('I ♥ you', ' '), 'i you')
     assert.equal(slug('I ♥ you', '_'), 'i_you')
+    assert.equal(slug('I ♥ you', {separator: ' '}), 'i you')
+    assert.equal(slug('I ♥ you', {separator: '_'}), 'i_you')
   })
 
   it('should convert letter-like chars into english alphanumeric chars', function () {
@@ -53,11 +55,14 @@ describe('slug()', function () {
     assert.equal(slug('Today I found £5'), 'today-i-found-5')
     assert.equal(slug('I ♥ you'), 'i-you')
     assert.equal(slug('Kevin Spacey', ' '), 'kevin spacey')
+    assert.equal(slug('Kevin Spacey', {separator: ' '}), 'kevin spacey')
   })
 
   it('should accept a regex of chars to strip rather than replace with dashes', function () {
     assert.equal(slug('Ben\'s slugg module', /'/g), 'bens-slugg-module')
     assert.equal(slug('Ben\'s slugg module', '_', /'/g), 'bens_slugg_module')
+    assert.equal(slug('Ben\'s slugg module', {toStrip: /'/g}), 'bens-slugg-module')
+    assert.equal(slug('Ben\'s slugg module', {separator: '_', toStrip: /'/g}), 'bens_slugg_module')
   })
 
   it('should strip any sort of quotemarks by default', function () {

--- a/test/slugg.test.js
+++ b/test/slugg.test.js
@@ -72,4 +72,8 @@ describe('slug()', function () {
     assert.equal(slug('He said: “I like turtles”'), 'he-said-i-like-turtles')
   })
 
+  it('should not convert to lower case if specified', function () {
+    assert.equal(slug('He said: “I like turtles”', { toLowerCase: false }), 'He-said-I-like-turtles')
+  })
+
 })


### PR DESCRIPTION
Hey @bengourley,

Here you have a dumb demo of what I was thinking about. The idea is to keep the interface as it is and make the second parameter to be (optionally) an options object. So you can now do:

``` js
slugg('My string', '_', /['"’‘”“]/g)
```

or

``` js
slugg('My string', { separator: '_', toStrip: /['"’‘”“]/g })
```
## Why?

I was thinking on adding one more parameter to the function, like this: `slugg(string, separator, toStrip, toLowerCase)` but it will be difficult because separator and toStrip are optional. So i thought it's worthy to start adding the possibility to have an options object. This way if we add more params the function interface will be always the same.

What do you think?

PS: Still missing some tests and better code 😉 
