### PR TITLE
Fix slugg with invalid parameters

### DIFF
--- a/slugg.js
+++ b/slugg.js
@@ -5,6 +5,10 @@ var defaultToStrip = /['"’‘”“]/g
 var defaultToLowerCase = true
 
 function slugg(string, separator, toStrip) {
+  // Ensure the given parameter is a string.
+  if (!(typeof string === 'string' || string instanceof String)) {
+    string = String((string == null) ? '' : string)
+  }
 
   var options = {}
 

--- a/test/slugg.test.js
+++ b/test/slugg.test.js
@@ -42,6 +42,13 @@ describe('slug()', function () {
     assert.equal(slug('I ♥ you', {separator: '_'}), 'i_you')
   })
 
+  it('should work with invalid parameters', function () {
+    assert.equal(slug(), '')
+    assert.equal(slug(45), '45')
+    assert.equal(slug(true), 'true')
+    assert.equal(slug(false), 'false')
+  })
+
   it('should convert letter-like chars into english alphanumeric chars', function () {
     for (var key in slug.chars) {
       if (slug.chars.hasOwnProperty(key)) {


### PR DESCRIPTION
This makes sure the given parameter is actually a string. Converts it to a string if needed.